### PR TITLE
feat: Add python version as an optional input in snyk workflow

### DIFF
--- a/.github/workflows/snyk_and_licence_check.yml
+++ b/.github/workflows/snyk_and_licence_check.yml
@@ -6,20 +6,20 @@ on:
         default: 'deploy/requirements.txt'
         required: false
         type: string
-
+      python-version:
+        description: "Version of python to install requirements. May affect specific package versions installed."
+        default: 3.7
+        type: string
 
 jobs:
   security-and-licence-check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ inputs.python-version }}
           cache: 'pip' # caching pip dependencies
       - name: Install dependencies
         env:


### PR DESCRIPTION
Adds an input for the python version with a default of 3.7. 

Should work the same where currently used, but allows the Python version to be customised in workflows. This is useful for example here https://github.com/MonolithAILtd/ds-prod-ms-al/pull/26/files where we aim to support Python 3.9. When synk tries to install the requirements in a 3.7 env, it fails due to at least one version of dependent package not being available in 3.7.